### PR TITLE
Use nanosleep instead of usleep.

### DIFF
--- a/echobot/echobot.c
+++ b/echobot/echobot.c
@@ -1,8 +1,13 @@
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <ctype.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #include <unistd.h>
 
@@ -99,7 +104,10 @@ int main(int argc, char **argv)
     while (1) {
         tox_iterate(tox, NULL);
 
-        usleep(tox_iteration_interval(tox) * 1000);
+        struct timespec pause;
+        pause.tv_sec = 0;
+        pause.tv_nsec = tox_iteration_interval(tox) * 1000 * 1000;
+        nanosleep(&pause, NULL);
     }
 
     tox_kill(tox);

--- a/util/misc_tools.c
+++ b/util/misc_tools.c
@@ -21,13 +21,20 @@
  * You should have received a copy of the GNU General Public License
  * along with Tox.  If not, see <http://www.gnu.org/licenses/>.
  */
+
+#ifndef _POSIX_C_SOURCE
+// For nanosleep().
+#define _POSIX_C_SOURCE 199309L
+#endif
+
+#include "misc_tools.h"
+
 #include <ctype.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include "misc_tools.h"
+#include <time.h>
 
 // You are responsible for freeing the return value!
 uint8_t *hex_string_to_bin(const char *hex_string)
@@ -113,6 +120,9 @@ void c_sleep(uint32_t x)
 #include <unistd.h>
 void c_sleep(uint32_t x)
 {
-    usleep(1000 * x);
+    struct timespec req;
+    req.tv_sec = x / 1000;
+    req.tv_nsec = (long)x % 1000 * 1000 * 1000;
+    nanosleep(&req, nullptr);
 }
 #endif

--- a/util/misc_tools.h
+++ b/util/misc_tools.h
@@ -5,6 +5,9 @@
 #define nullptr NULL
 #endif
 
+#include <stddef.h>
+#include <stdint.h>
+
 /* Reimplementation of strncasecmp() function from strings.h, as strings.h is
  * POSIX and not portable. Specifically it doesn't exist on MSVC.
  */


### PR DESCRIPTION
The latter is obsolete since 2001 and removed since 2008.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxins/12)
<!-- Reviewable:end -->
