### PR TITLE
Reduce some warnings-as-errors back to warnings.

### DIFF
--- a/tox_shell/BUILD.bazel
+++ b/tox_shell/BUILD.bazel
@@ -1,6 +1,7 @@
 cc_binary(
     name = "tox_shell",
     srcs = ["tox_shell.c"],
+    copts = ["-Wno-error=unused-result"],
     linkopts = ["-lutil"],
     deps = [
         "//c-toxcore",

--- a/toxvpn/BUILD.bazel
+++ b/toxvpn/BUILD.bazel
@@ -26,7 +26,6 @@ cc_binary(
         "-frtti",  # json.hpp uses dynamic_cast.
         "'-DBOOTSTRAP_FILE=\"toxins/toxvpn/import/res/bootstrap.json\"'",
         "-DZMQ",
-        "-Wno-error=sign-compare",
     ],
     deps = [
         "//c-toxcore",


### PR DESCRIPTION
We need to fix these, but for now this avoids build failures.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxins/13)
<!-- Reviewable:end -->
