### PR TITLE
refactor: Update echobot

### DIFF
--- a/echobot/echobot.c
+++ b/echobot/echobot.c
@@ -18,7 +18,6 @@ typedef struct DHT_node {
     const char *ip;
     uint16_t port;
     const char key_hex[TOX_PUBLIC_KEY_SIZE * 2 + 1];
-    unsigned char key_bin[TOX_PUBLIC_KEY_SIZE];
 } DHT_node;
 
 void friend_request_cb(Tox *tox, const uint8_t *public_key, const uint8_t *message, size_t length,
@@ -68,20 +67,21 @@ int main(int argc, char **argv)
     tox_self_set_status_message(tox, (const uint8_t *)status_message, strlen(status_message), NULL);
 
     DHT_node nodes[] = {
-        {"178.62.250.138",             33445, "788236D34978D1D5BD822F0A5BEBD2C53C64CC31CD3149350EE27D4D9A2F9B6B", {0}},
-        {"2a03:b0c0:2:d0::16:1",       33445, "788236D34978D1D5BD822F0A5BEBD2C53C64CC31CD3149350EE27D4D9A2F9B6B", {0}},
-        {"tox.zodiaclabs.org",         33445, "A09162D68618E742FFBCA1C2C70385E6679604B2D80EA6E84AD0996A1AC8A074", {0}},
-        {"163.172.136.118",            33445, "2C289F9F37C20D09DA83565588BF496FAB3764853FA38141817A72E3F18ACA0B", {0}},
-        {"2001:bc8:4400:2100::1c:50f", 33445, "2C289F9F37C20D09DA83565588BF496FAB3764853FA38141817A72E3F18ACA0B", {0}},
-        {"128.199.199.197",            33445, "B05C8869DBB4EDDD308F43C1A974A20A725A36EACCA123862FDE9945BF9D3E09", {0}},
-        {"2400:6180:0:d0::17a:a001",   33445, "B05C8869DBB4EDDD308F43C1A974A20A725A36EACCA123862FDE9945BF9D3E09", {0}},
-        {"node.tox.biribiri.org",      33445, "F404ABAA1C99A9D37D61AB54898F56793E1DEF8BD46B1038B9D822E8460FAB67", {0}}
+        {"85.143.221.42",                      33445, "DA4E4ED4B697F2E9B000EEFE3A34B554ACD3F45F5C96EAEA2516DD7FF9AF7B43"},
+        {"2a04:ac00:1:9f00:5054:ff:fe01:becd", 33445, "DA4E4ED4B697F2E9B000EEFE3A34B554ACD3F45F5C96EAEA2516DD7FF9AF7B43"},
+        {"78.46.73.141",                       33445, "02807CF4F8BB8FB390CC3794BDF1E8449E9A8392C5D3F2200019DA9F1E812E46"},
+        {"2a01:4f8:120:4091::3",               33445, "02807CF4F8BB8FB390CC3794BDF1E8449E9A8392C5D3F2200019DA9F1E812E46"},
+        {"tox.initramfs.io",                   33445, "3F0A45A268367C1BEA652F258C85F4A66DA76BCAA667A49E770BCC4917AB6A25"},
+        {"tox2.abilinski.com",                 33445, "7A6098B590BDC73F9723FC59F82B3F9085A64D1B213AAF8E610FD351930D052D"},
+        {"205.185.115.131",                       53, "3091C6BEB2A993F1C6300C16549FABA67098FF3D62C6D253828B531470B53D68"},
+        {"tox.kurnevsky.net",                  33445, "82EF82BA33445A1F91A7DB27189ECFC0C013E06E3DA71F588ED692BED625EC23"}
     };
 
     for (size_t i = 0; i < sizeof(nodes) / sizeof(DHT_node); i ++) {
-        sodium_hex2bin(nodes[i].key_bin, sizeof(nodes[i].key_bin),
-                       nodes[i].key_hex, sizeof(nodes[i].key_hex) - 1, NULL, NULL, NULL);
-        tox_bootstrap(tox, nodes[i].ip, nodes[i].port, nodes[i].key_bin, NULL);
+        unsigned char key_bin[TOX_PUBLIC_KEY_SIZE];
+        sodium_hex2bin(key_bin, sizeof(key_bin), nodes[i].key_hex, sizeof(nodes[i].key_hex) - 1,
+                       NULL, NULL, NULL);
+        tox_bootstrap(tox, nodes[i].ip, nodes[i].port, key_bin, NULL);
     }
 
     uint8_t tox_id_bin[TOX_ADDRESS_SIZE];
@@ -100,6 +100,8 @@ int main(int argc, char **argv)
     tox_callback_friend_message(tox, friend_message_cb);
 
     tox_callback_self_connection_status(tox, self_connection_status_cb);
+
+    printf("Connecting...\n");
 
     while (1) {
         tox_iterate(tox, NULL);

--- a/echobot/echobot.c
+++ b/echobot/echobot.c
@@ -20,10 +20,100 @@ typedef struct DHT_node {
     const char key_hex[TOX_PUBLIC_KEY_SIZE * 2 + 1];
 } DHT_node;
 
+const char *savedata_filename = "savedata.tox";
+const char *savedata_tmp_filename = "savedata.tox.tmp";
+
+Tox *create_tox()
+{
+    Tox *tox;
+
+    struct Tox_Options options;
+
+    tox_options_default(&options);
+
+    FILE *f = fopen(savedata_filename, "rb");
+
+    if (f) {
+        fseek(f, 0, SEEK_END);
+        long fsize = ftell(f);
+        fseek(f, 0, SEEK_SET);
+
+        uint8_t *savedata = malloc(fsize);
+
+        fread(savedata, fsize, 1, f);
+        fclose(f);
+
+        options.savedata_type = TOX_SAVEDATA_TYPE_TOX_SAVE;
+        options.savedata_data = savedata;
+        options.savedata_length = fsize;
+
+        tox = tox_new(&options, NULL);
+
+        free(savedata);
+    } else {
+        tox = tox_new(&options, NULL);
+    }
+
+    return tox;
+}
+
+void update_savedata_file(const Tox *tox)
+{
+    size_t size = tox_get_savedata_size(tox);
+    uint8_t *savedata = malloc(size);
+    tox_get_savedata(tox, savedata);
+
+    FILE *f = fopen(savedata_tmp_filename, "wb");
+    fwrite(savedata, size, 1, f);
+    fclose(f);
+
+    rename(savedata_tmp_filename, savedata_filename);
+
+    free(savedata);
+}
+
+void bootstrap(Tox *tox)
+{
+    DHT_node nodes[] = {
+        {"85.143.221.42",                      33445, "DA4E4ED4B697F2E9B000EEFE3A34B554ACD3F45F5C96EAEA2516DD7FF9AF7B43"},
+        {"2a04:ac00:1:9f00:5054:ff:fe01:becd", 33445, "DA4E4ED4B697F2E9B000EEFE3A34B554ACD3F45F5C96EAEA2516DD7FF9AF7B43"},
+        {"78.46.73.141",                       33445, "02807CF4F8BB8FB390CC3794BDF1E8449E9A8392C5D3F2200019DA9F1E812E46"},
+        {"2a01:4f8:120:4091::3",               33445, "02807CF4F8BB8FB390CC3794BDF1E8449E9A8392C5D3F2200019DA9F1E812E46"},
+        {"tox.initramfs.io",                   33445, "3F0A45A268367C1BEA652F258C85F4A66DA76BCAA667A49E770BCC4917AB6A25"},
+        {"tox2.abilinski.com",                 33445, "7A6098B590BDC73F9723FC59F82B3F9085A64D1B213AAF8E610FD351930D052D"},
+        {"205.185.115.131",                       53, "3091C6BEB2A993F1C6300C16549FABA67098FF3D62C6D253828B531470B53D68"},
+        {"tox.kurnevsky.net",                  33445, "82EF82BA33445A1F91A7DB27189ECFC0C013E06E3DA71F588ED692BED625EC23"}
+    };
+
+    for (size_t i = 0; i < sizeof(nodes) / sizeof(DHT_node); i ++) {
+        unsigned char key_bin[TOX_PUBLIC_KEY_SIZE];
+        sodium_hex2bin(key_bin, sizeof(key_bin), nodes[i].key_hex, sizeof(nodes[i].key_hex) - 1,
+                       NULL, NULL, NULL);
+        tox_bootstrap(tox, nodes[i].ip, nodes[i].port, key_bin, NULL);
+    }
+}
+
+void print_tox_id(Tox *tox)
+{
+    uint8_t tox_id_bin[TOX_ADDRESS_SIZE];
+    tox_self_get_address(tox, tox_id_bin);
+
+    char tox_id_hex[TOX_ADDRESS_SIZE * 2 + 1];
+    sodium_bin2hex(tox_id_hex, sizeof(tox_id_hex), tox_id_bin, sizeof(tox_id_bin));
+
+    for (size_t i = 0; i < sizeof(tox_id_hex) - 1; i ++) {
+        tox_id_hex[i] = toupper(tox_id_hex[i]);
+    }
+
+    printf("Tox ID: %s\n", tox_id_hex);
+}
+
 void friend_request_cb(Tox *tox, const uint8_t *public_key, const uint8_t *message, size_t length,
                        void *user_data)
 {
     tox_friend_add_norequest(tox, public_key, NULL);
+
+    update_savedata_file(tox);
 }
 
 void friend_message_cb(Tox *tox, uint32_t friend_number, Tox_Message_Type type, const uint8_t *message,
@@ -58,7 +148,7 @@ int main(int argc, char **argv)
         }
     }
 
-    Tox *tox = tox_new(NULL, NULL);
+    Tox *tox = create_tox();
 
     const char *name = "Echo Bot";
     tox_self_set_name(tox, (const uint8_t *)name, strlen(name), NULL);
@@ -66,40 +156,16 @@ int main(int argc, char **argv)
     const char *status_message = "Echoing your messages";
     tox_self_set_status_message(tox, (const uint8_t *)status_message, strlen(status_message), NULL);
 
-    DHT_node nodes[] = {
-        {"85.143.221.42",                      33445, "DA4E4ED4B697F2E9B000EEFE3A34B554ACD3F45F5C96EAEA2516DD7FF9AF7B43"},
-        {"2a04:ac00:1:9f00:5054:ff:fe01:becd", 33445, "DA4E4ED4B697F2E9B000EEFE3A34B554ACD3F45F5C96EAEA2516DD7FF9AF7B43"},
-        {"78.46.73.141",                       33445, "02807CF4F8BB8FB390CC3794BDF1E8449E9A8392C5D3F2200019DA9F1E812E46"},
-        {"2a01:4f8:120:4091::3",               33445, "02807CF4F8BB8FB390CC3794BDF1E8449E9A8392C5D3F2200019DA9F1E812E46"},
-        {"tox.initramfs.io",                   33445, "3F0A45A268367C1BEA652F258C85F4A66DA76BCAA667A49E770BCC4917AB6A25"},
-        {"tox2.abilinski.com",                 33445, "7A6098B590BDC73F9723FC59F82B3F9085A64D1B213AAF8E610FD351930D052D"},
-        {"205.185.115.131",                       53, "3091C6BEB2A993F1C6300C16549FABA67098FF3D62C6D253828B531470B53D68"},
-        {"tox.kurnevsky.net",                  33445, "82EF82BA33445A1F91A7DB27189ECFC0C013E06E3DA71F588ED692BED625EC23"}
-    };
+    bootstrap(tox);
 
-    for (size_t i = 0; i < sizeof(nodes) / sizeof(DHT_node); i ++) {
-        unsigned char key_bin[TOX_PUBLIC_KEY_SIZE];
-        sodium_hex2bin(key_bin, sizeof(key_bin), nodes[i].key_hex, sizeof(nodes[i].key_hex) - 1,
-                       NULL, NULL, NULL);
-        tox_bootstrap(tox, nodes[i].ip, nodes[i].port, key_bin, NULL);
-    }
-
-    uint8_t tox_id_bin[TOX_ADDRESS_SIZE];
-    tox_self_get_address(tox, tox_id_bin);
-
-    char tox_id_hex[TOX_ADDRESS_SIZE * 2 + 1];
-    sodium_bin2hex(tox_id_hex, sizeof(tox_id_hex), tox_id_bin, sizeof(tox_id_bin));
-
-    for (size_t i = 0; i < sizeof(tox_id_hex) - 1; i ++) {
-        tox_id_hex[i] = toupper(tox_id_hex[i]);
-    }
-
-    printf("Tox ID: %s\n", tox_id_hex);
+    print_tox_id(tox);
 
     tox_callback_friend_request(tox, friend_request_cb);
     tox_callback_friend_message(tox, friend_message_cb);
 
     tox_callback_self_connection_status(tox, self_connection_status_cb);
+
+    update_savedata_file(tox);
 
     printf("Connecting...\n");
 


### PR DESCRIPTION
- Added working bootstrap nodes
- Removed the useless 4th member of the `DHT_node` struct
- Updated to [the full example from wiki](https://wiki.tox.chat/developers/client_examples/echo_bot) instead of the minimal one (more functions + creates toxsave file)
- Astyled with c-toxcore's rules
- No warnings with `-Wall -Wextra -pedantic -Wno-unused-parameter`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxins/20)
<!-- Reviewable:end -->
