### PR TITLE
chore: Remove travis; add cirrus ci.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,13 @@
+---
+cirrus-ci_task:
+  container:
+    image: toxchat/toktok-stack:0.0.31-release
+    cpu: 2
+    memory: 6G
+  configure_script:
+    - git submodule update --init --depth=10 --recursive
+    - /src/workspace/tools/inject-repo toxins
+  test_all_script:
+    - cd /src/workspace && bazel test -k
+        --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST
+        //toxins/...

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -11,7 +11,6 @@ branches:
     protection:
       required_status_checks:
         contexts:
-          - Codacy/PR Quality Review
-          - CodeFactor
-          - Travis CI - Pull Request
-          - code-review/reviewable
+          - "cirrus-ci"
+          - "Codacy Static Code Analysis"
+          - "code-review/reviewable"


### PR DESCRIPTION
This uses toktok-stack to build the toxins and check whether they support `--help`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxins/28)
<!-- Reviewable:end -->
