### PR TITLE
chore: Disable targets for cross-compilation.

### DIFF
--- a/toxvpn/BUILD.bazel
+++ b/toxvpn/BUILD.bazel
@@ -29,6 +29,7 @@ cc_binary(
         "'-DBOOTSTRAP_FILE=\"toxins/toxvpn/import/res/bootstrap.json\"'",
         "-DZMQ",
     ],
+    tags = ["no-cross"],
     deps = [
         "//c-toxcore",
         "@json",
@@ -51,4 +52,5 @@ sh_test(
     srcs = [":toxvpn"],
     args = ["--help"],
     data = ["import/res/bootstrap.json"],
+    tags = ["no-cross"],
 )


### PR DESCRIPTION
This way we can do bazel build //... when cross-compiling.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxins/34)
<!-- Reviewable:end -->
