### PR TITLE
chore: Mark most toxins as no-windows.

### DIFF
--- a/echobot/BUILD.bazel
+++ b/echobot/BUILD.bazel
@@ -3,7 +3,11 @@ load("@rules_cc//cc:defs.bzl", "cc_binary")
 cc_binary(
     name = "echobot",
     srcs = ["echobot.c"],
-    deps = ["//c-toxcore"],
+    tags = ["no-windows"],
+    deps = [
+        "//c-toxcore",
+        "@libsodium",
+    ],
 )
 
 sh_test(
@@ -11,4 +15,5 @@ sh_test(
     size = "small",
     srcs = [":echobot"],
     args = ["--help"],
+    tags = ["no-windows"],
 )

--- a/irc_syncbot/BUILD.bazel
+++ b/irc_syncbot/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_cc//cc:defs.bzl", "cc_binary")
 cc_binary(
     name = "irc_syncbot",
     srcs = ["irc_syncbot.c"],
+    tags = ["no-windows"],
     deps = [
         "//c-toxcore",
         "//toxins/util:misc_tools",
@@ -14,4 +15,5 @@ sh_test(
     size = "small",
     srcs = [":irc_syncbot"],
     args = ["--help"],
+    tags = ["no-windows"],
 )

--- a/tox_shell/BUILD.bazel
+++ b/tox_shell/BUILD.bazel
@@ -4,6 +4,7 @@ cc_binary(
     name = "tox_shell",
     srcs = ["tox_shell.c"],
     linkopts = ["-lutil"],
+    tags = ["no-windows"],
     deps = [
         "//c-toxcore",
         "//toxins/util:misc_tools",
@@ -15,4 +16,5 @@ sh_test(
     size = "small",
     srcs = [":tox_shell"],
     args = ["--help"],
+    tags = ["no-windows"],
 )

--- a/tox_sync/BUILD.bazel
+++ b/tox_sync/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_cc//cc:defs.bzl", "cc_binary")
 cc_binary(
     name = "tox_sync",
     srcs = ["tox_sync.c"],
+    tags = ["no-windows"],
     deps = [
         "//c-toxcore",
         "//toxins/util:misc_tools",
@@ -14,4 +15,5 @@ sh_test(
     size = "small",
     srcs = [":tox_sync"],
     args = ["--help"],
+    tags = ["no-windows"],
 )

--- a/toxvpn/BUILD.bazel
+++ b/toxvpn/BUILD.bazel
@@ -43,6 +43,7 @@ cc_binary(
 cc_binary(
     name = "toxvpn-remote",
     srcs = ["import/src/toxvpn-remote.cpp"],
+    tags = ["no-cross"],
     deps = ["@libzmq"],
 )
 


### PR DESCRIPTION
These use unix headers. Easy to fix, but not a priority for now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxins/38)
<!-- Reviewable:end -->
