### PR TITLE
cleanup: Fix new clang warnings: malloc needs to be cast.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 ---
 bazel-opt_task:
   container:
-    image: toxchat/toktok-stack:latest-release
+    image: toxchat/toktok-stack:latest
     cpu: 2
     memory: 6G
   configure_script:
@@ -9,5 +9,5 @@ bazel-opt_task:
     - /src/workspace/tools/inject-repo toxins
   test_all_script:
     - cd /src/workspace && bazel test -k
-        --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST
+        --remote_cache=http://$CIRRUS_HTTP_CACHE_HOST
         //toxins/...

--- a/echobot/echobot.c
+++ b/echobot/echobot.c
@@ -39,7 +39,7 @@ Tox *create_tox(void)
         long fsize = ftell(f);
         fseek(f, 0, SEEK_SET);
 
-        uint8_t *savedata = malloc(fsize);
+        uint8_t *savedata = (uint8_t *)malloc(fsize);
 
         if (savedata == NULL) {
             return NULL;
@@ -69,7 +69,7 @@ Tox *create_tox(void)
 void update_savedata_file(const Tox *tox)
 {
     size_t size = tox_get_savedata_size(tox);
-    uint8_t *savedata = malloc(size);
+    uint8_t *savedata = (uint8_t *)malloc(size);
 
     if (savedata == NULL) {
         fprintf(stderr, "Failed to allocate memory for save data\n");


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toxins/45)
<!-- Reviewable:end -->
